### PR TITLE
Support Java Modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>org.ainslec.picocog</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -57,8 +67,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Java11でJava Modulesに対応したツールを作成しようとしています。  

Java Modulesに対応したツールを作成するときには、Unnamed Moduleを直接参照できません。  
Automatic Moduleにすることで、この制限に引っかからないようにします。  

pom.xmlを変更して、MANIFEST.MFに必要な設定が出力されるようにします。  
Mavenへの登録も希望します。  
