### PR TITLE
Remove leading underscore from field names

### DIFF
--- a/src/main/java/org/ainslec/picocog/IndentedLine.java
+++ b/src/main/java/org/ainslec/picocog/IndentedLine.java
@@ -21,13 +21,13 @@ package org.ainslec.picocog;
  *
  */
 public class IndentedLine implements PicoWriterItem {
-   String _line;
-   int    _indent;
+   String line;
+   int    indent;
    public IndentedLine(String line, int indent) {
-      _line   = line;
-      _indent = indent;
+      this.line   = line;
+      this.indent = indent;
    }
-   public String getLine() { return _line; }
-   public int getIndent()  { return _indent; }
-   @Override public String toString() { return _indent + ":" + _line; }
+   public String getLine() { return line; }
+   public int getIndent()  { return indent; }
+   @Override public String toString() { return indent + ":" + line; }
 }

--- a/src/main/java/org/ainslec/picocog/PicoWriter.java
+++ b/src/main/java/org/ainslec/picocog/PicoWriter.java
@@ -23,83 +23,83 @@ import java.util.List;
  * @author Chris Ainsley
  */
 public class PicoWriter implements PicoWriterItem {
-   private static final String      SEP                         = "\n";
-   private static final String      DI                          = "   " ;
-   private int                      _indents                    = -1;
-   private int                      _numLines                   = 0;
-   private boolean                  _generateIfEmpty            = true;
-   private boolean                  _generate                   = true;
-   boolean                          _normalizeAdjacentBlankRows = false;
+   private static final String      SEP                        = "\n";
+   private static final String      DI                         = "   " ;
+   private int                      indents                    = -1;
+   private int                      numLines                   = 0;
+   private boolean                  generateIfEmpty            = true;
+   private boolean                  generate                   = true;
+   boolean                          normalizeAdjacentBlankRows = false;
    
-   private boolean                  _isDirty                    = false;
-   private List<String[]>           _rows                       = new ArrayList<>(); // Used for aligning columns in the multi string writeln method.
-   private List<PicoWriterItem>     _content                    = new ArrayList <PicoWriterItem>();
-   private StringBuilder            _sb                         = new StringBuilder();
-   private String                   _ic   /* Indent chars*/     = DI;
+   private boolean                  isDirty                    = false;
+   private List<String[]>           rows                       = new ArrayList<>(); // Used for aligning columns in the multi string writeln method.
+   private List<PicoWriterItem>     content                    = new ArrayList <PicoWriterItem>();
+   private StringBuilder            stringBuilder              = new StringBuilder();
+   private String                   identChars                 = DI;
 
    public PicoWriter () {
-      _indents = 0;
+      indents = 0;
    }
    public PicoWriter (String indentText) {
-      _indents = 0;
-      _ic = indentText == null ? DI : indentText;
+      indents = 0;
+      identChars = indentText == null ? DI : indentText;
    }
    private PicoWriter (int initialIndent, String indentText) {
-      _indents = initialIndent < 0 ? 0 : initialIndent;
-      _ic = indentText == null ? DI : indentText;
+      indents = initialIndent < 0 ? 0 : initialIndent;
+      identChars = indentText == null ? DI : indentText;
    }
    public void indentRight() {
       flushRows();
-      _indents++;
+      indents++;
    }
    public void indentLeft() {
       flushRows();
-      _indents--;
-      if (_indents < 0) {
+      indents--;
+      if (indents < 0) {
          throw new RuntimeException("Local indent cannot be less than zero");
       }
    }
 
    public final PicoWriter createDeferredWriter() {
       
-      if (_sb.length() > 0) {
+      if (stringBuilder.length() > 0) {
          flush();
-         _numLines++;
+         numLines++;
       }
       
-      PicoWriter inner = new PicoWriter(_indents, _ic);
-      _content.add(inner);
-      _numLines++;
+      PicoWriter inner = new PicoWriter(indents, identChars);
+      content.add(inner);
+      numLines++;
       
       return inner;
    }
    
    public final PicoWriter writeln(PicoWriter inner) {
       
-      if (_sb.length() > 0) {
+      if (stringBuilder.length() > 0) {
          flush();
-         _numLines++;
+         numLines++;
       }
       
-      adjustIndents(inner, this._indents, this._ic);
+      adjustIndents(inner, indents, identChars);
       
-      _content.add(inner);
-      _numLines++;
+      content.add(inner);
+      numLines++;
       
       return this;
    }
    
    private void adjustIndents(PicoWriter inner, int indents, String ic) {
       if (inner != null) {
-         for ( PicoWriterItem item : inner._content) {
+         for ( PicoWriterItem item : inner.content) {
             if (item instanceof PicoWriter) {
                adjustIndents((PicoWriter) item, indents, ic);
             } else if (item instanceof IndentedLine) {
                IndentedLine il = (IndentedLine) item;
-               il._indent = il._indent + indents;
+               il.indent = il.indent + indents;
             }
          }
-         inner._ic = ic;
+         inner.identChars = ic;
       }
    }
    
@@ -125,8 +125,8 @@ public class PicoWriter implements PicoWriterItem {
    }
    
    public PicoWriter writeln(String string) {
-      _numLines++;
-      _sb.append(string);
+      numLines++;
+      stringBuilder.append(string);
       flush();
       return this;
    }
@@ -137,9 +137,9 @@ public class PicoWriter implements PicoWriterItem {
     * @return Returns the current instance of the {@link PicoWriter} object
     */
    public PicoWriter writeln(String ... strings) {
-      _rows.add(strings);
-      _isDirty = true;
-      _numLines++;
+      rows.add(strings);
+      isDirty = true;
+      numLines++;
       return this;
    }
    
@@ -155,20 +155,20 @@ public class PicoWriter implements PicoWriterItem {
       PicoWriter ggg = createDeferredWriter();
       indentLeft();
       writeln(endLine);
-      _isDirty = true;
-      _numLines+=2;
+      isDirty = true;
+      numLines+=2;
       return ggg;
    }
    
    
    public boolean isEmpty() {
-      return _numLines == 0;
+      return numLines == 0;
    }
    
    public void write(String string)  {
-      _numLines++;
-      _isDirty = true;
-      _sb.append(string);
+      numLines++;
+      isDirty = true;
+      stringBuilder.append(string);
    }
    
    private static final void writeIndentedLine(final StringBuilder sb, final int indentBase, final String indentText, final String line) {
@@ -181,7 +181,7 @@ public class PicoWriter implements PicoWriterItem {
    
    private boolean render(StringBuilder sb, int indentBase, boolean normalizeAdjacentBlankRows, boolean lastRowWasBlank) {
       
-      if (_isDirty) {
+      if (isDirty) {
          flush();
       }
       
@@ -190,7 +190,7 @@ public class PicoWriter implements PicoWriterItem {
          return lastRowWasBlank;
       }
        // TODO :: Will make this configurable
-      for (PicoWriterItem item : _content) {
+      for (PicoWriterItem item : content) {
          if (item instanceof IndentedLine) {
             IndentedLine il           = (IndentedLine)item;
             final String lineText     = il.getLine();
@@ -200,7 +200,7 @@ public class PicoWriter implements PicoWriterItem {
             if (normalizeAdjacentBlankRows && lastRowWasBlank && thisRowIsBlank) {
                // Don't write the line if we already had a blank line
             } else {
-               writeIndentedLine(sb, indentLevelHere, _ic, lineText);
+               writeIndentedLine(sb, indentLevelHere, identChars, lineText);
             }
             
             lastRowWasBlank = thisRowIsBlank;
@@ -216,36 +216,36 @@ public class PicoWriter implements PicoWriterItem {
    }
 
    public boolean isMethodBodyEmpty() {
-      return _content.size() == 0 && _sb.length() == 0;
+      return content.size() == 0 && stringBuilder.length() == 0;
    }
    
    public boolean isGenerateIfEmpty() {
-      return _generateIfEmpty;
+      return generateIfEmpty;
    }
    
    public void setGenerateIfEmpty(boolean generateIfEmpty) {
-      _generateIfEmpty  = generateIfEmpty;
+      this.generateIfEmpty = generateIfEmpty;
    }
    
    public boolean isGenerate() {
-      return _generate;
+      return generate;
    }
    
    public void setGenerate(boolean generate) {
-      _generate = generate;
+      this.generate = generate;
    }
    
    private void flush() {
       flushRows();
-      _content.add(new IndentedLine(_sb.toString(), _indents));
-      _sb.setLength(0);
-      _isDirty = false;
+      content.add(new IndentedLine(stringBuilder.toString(), indents));
+      stringBuilder.setLength(0);
+      isDirty = false;
    }
    
    private void flushRows() {
-      if (_rows.size() > 0) {
+      if (rows.size() > 0) {
          ArrayList<Integer> maxWidth = new ArrayList<>();
-         for (String[] columns : _rows) {
+         for (String[] columns : rows) {
             int numColumns = columns.length;
             for (int i=0; i < numColumns; i++) {
                String currentColumnStringValue = columns[i];
@@ -262,7 +262,7 @@ public class PicoWriter implements PicoWriterItem {
          
          StringBuilder rowSB = new StringBuilder();
          
-         for (String[] columns : _rows) {
+         for (String[] columns : rows) {
             int numColumns = columns.length;
             for (int i=0; i < numColumns; i++) {
                String currentColumnStringValue = columns[i];
@@ -276,21 +276,21 @@ public class PicoWriter implements PicoWriterItem {
                   }
                }
             }
-            _content.add(new IndentedLine(rowSB.toString(), _indents));
+            content.add(new IndentedLine(rowSB.toString(), indents));
             rowSB.setLength(0);
          }
-         _rows.clear();
+         rows.clear();
       }
    }
    
 
    public void setNormalizeAdjacentBlankRows(boolean normalizeAdjacentBlankRows) {
-      _normalizeAdjacentBlankRows = normalizeAdjacentBlankRows;
+      this.normalizeAdjacentBlankRows = normalizeAdjacentBlankRows;
    }
    
    public String toString(int indentBase) {
       StringBuilder sb = new StringBuilder();
-      render(sb, indentBase, _normalizeAdjacentBlankRows, false /* lastRowWasBlank */);
+      render(sb, indentBase, normalizeAdjacentBlankRows, false /* lastRowWasBlank */);
       return sb.toString();
    }
    


### PR DESCRIPTION
The fields names in `PicoWriter` and `IndentedLine` have leading underscores. As stated in #4, this goes against common Java code conventions, and should be avoided. This pull request refactors both classes by removing leading underscores from the names of their fields.

Closes #4